### PR TITLE
fix(theme): prevent bold headers in Fiori 3 theme (fixes #4320)

### DIFF
--- a/src/themelib_sap_fiori_3/src/sap/ui/core/themes/sap_fiori_3/base.less
+++ b/src/themelib_sap_fiori_3/src/sap/ui/core/themes/sap_fiori_3/base.less
@@ -704,7 +704,7 @@
 
 // [Tags "!Protected"]
 // [Protected "!true"]
-@sapFontHeaderFamily: @sapFontFamily;
+@sapFontHeaderFamily: "72", "72full", Arial, Helvetica, sans-serif;
 
 // [Tags "!Protected"]
 // [Protected "!true"]
@@ -3585,9 +3585,6 @@
 @sapChart_Sequence_1_Plus1: lighten(saturate(@sapChart_Sequence_1, 2), 7);
 @sapChart_Sequence_1_Plus1_TextColor: contrast(@sapChart_Sequence_1_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
 @sapChart_Sequence_1_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_1_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_1: @sapChart_OrderedColor_1;
 @sapChart_Sequence_1_TextColor: contrast(@sapChart_Sequence_1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
 @sapChart_Sequence_1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3613,7 +3610,7 @@
 @sapChart_Sequence_2_Plus2: lighten(saturate(@sapChart_Sequence_2, 10), 15);
 @sapChart_Sequence_2_Plus2_TextColor: contrast(@sapChart_Sequence_2_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_2_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_2_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_2_Plus1: lighten(saturate(@sapChart_Sequence_2, 5), 7);
+@sapChart_Sequence_2_Plus1: lighten(saturate(@sapChart_Sequence_2, 2), 7);
 @sapChart_Sequence_2_Plus1_TextColor: contrast(@sapChart_Sequence_2_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_2_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_2_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 
@@ -3626,7 +3623,7 @@
 @sapChart_Sequence_2_Minus1: darken(desaturate(@sapChart_Sequence_2, 1), 9);
 @sapChart_Sequence_2_Minus1_TextColor: contrast(@sapChart_Sequence_2_Minus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_2_Minus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_2_Minus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_2_Minus2: darken(saturate(@sapChart_Sequence_2, 21), 17);
+@sapChart_Sequence_2_Minus2: darken(saturate(@sapChart_Sequence_2, 10), 17);
 @sapChart_Sequence_2_Minus2_TextColor: contrast(@sapChart_Sequence_2_Minus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_2_Minus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_2_Minus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_2_Minus3: darken(@sapChart_Sequence_2, 20);
@@ -3641,41 +3638,38 @@
 @sapChart_Sequence_3_Plus3: lighten(desaturate(@sapChart_Sequence_3, 32), 31);
 @sapChart_Sequence_3_Plus3_TextColor: contrast(@sapChart_Sequence_3_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_3_Plus2: lighten(desaturate(@sapChart_Sequence_3, 31), 20);
+@sapChart_Sequence_3_Plus2: lighten(desaturate(@sapChart_Sequence_3, 5), 15);
 @sapChart_Sequence_3_Plus2_TextColor: contrast(@sapChart_Sequence_3_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_3_Plus1: lighten(desaturate(@sapChart_Sequence_3, 26), 10);
+@sapChart_Sequence_3_Plus1: lighten(desaturate(@sapChart_Sequence_3, 2), 7);
 @sapChart_Sequence_3_Plus1_TextColor: contrast(@sapChart_Sequence_3_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_3: @sapChart_OrderedColor_3;
 @sapChart_Sequence_3_TextColor: contrast(@sapChart_Sequence_3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_3_BorderColor: @sapChart_Sequence_3_Minus1;
-@sapChart_Sequence_3_Minus1: darken(saturate(@sapChart_Sequence_3, 8), 8);
+@sapChart_Sequence_3_Minus1: darken(desaturate(@sapChart_Sequence_3, 8), 8);
 @sapChart_Sequence_3_Minus1_TextColor: contrast(@sapChart_Sequence_3_Minus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Minus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Minus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_3_Minus2: darken(saturate(@sapChart_Sequence_3, 21), 15);
 @sapChart_Sequence_3_Minus2_TextColor: contrast(@sapChart_Sequence_3_Minus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Minus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Minus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_3_Minus3: darken(@sapChart_Sequence_3, 20);
+@sapChart_Sequence_3_Minus3: darken(saturate(@sapChart_Sequence_3, 21), 20);
 @sapChart_Sequence_3_Minus3_TextColor: contrast(@sapChart_Sequence_3_Minus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Minus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Minus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_3_Minus4: darken(@sapChart_Sequence_3, 23);
+@sapChart_Sequence_3_Minus4: darken(saturate(@sapChart_Sequence_3, 21), 25);
 @sapChart_Sequence_3_Minus4_TextColor: contrast(@sapChart_Sequence_3_Minus4, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Minus4_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Minus4_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_3_Minus5: darken(@sapChart_Sequence_3, 26);
+@sapChart_Sequence_3_Minus5: darken(saturate(@sapChart_Sequence_3, 21), 32);
 @sapChart_Sequence_3_Minus5_TextColor: contrast(@sapChart_Sequence_3_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_3_Minus5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_3_Minus5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_4_Plus3: lighten(saturate(@sapChart_Sequence_4, 1), 23);
+@sapChart_Sequence_4_Plus3: lighten(desaturate(@sapChart_Sequence_4, 1), 15);
 @sapChart_Sequence_4_Plus3_TextColor: contrast(@sapChart_Sequence_4_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_4_Plus2: lighten(@sapChart_Sequence_4, 15);
+@sapChart_Sequence_4_Plus2: lighten(desaturate(@sapChart_Sequence_4, 5), 15);
 @sapChart_Sequence_4_Plus2_TextColor: contrast(@sapChart_Sequence_4_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_4_Plus1: lighten(@sapChart_Sequence_4, 7);
+@sapChart_Sequence_4_Plus1: lighten(desaturate(@sapChart_Sequence_4, 2), 7);
 @sapChart_Sequence_4_Plus1_TextColor: contrast(@sapChart_Sequence_4_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 
@@ -3691,10 +3685,10 @@
 @sapChart_Sequence_4_Minus2: darken(saturate(@sapChart_Sequence_4, 10), 17);
 @sapChart_Sequence_4_Minus2_TextColor: contrast(@sapChart_Sequence_4_Minus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Minus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Minus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_4_Minus3: darken(@sapChart_Sequence_4, 22);
+@sapChart_Sequence_4_Minus3: darken(saturate(@sapChart_Sequence_4, 10), 20);
 @sapChart_Sequence_4_Minus3_TextColor: contrast(@sapChart_Sequence_4_Minus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Minus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Minus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_4_Minus4: darken(@sapChart_Sequence_4, 30);
+@sapChart_Sequence_4_Minus4: darken(saturate(@sapChart_Sequence_4, 10), 25);
 @sapChart_Sequence_4_Minus4_TextColor: contrast(@sapChart_Sequence_4_Minus4, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_4_Minus4_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_4_Minus4_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_4_Minus5: darken(@sapChart_Sequence_4, 35);
@@ -3703,15 +3697,12 @@
 @sapChart_Sequence_5_Plus3: lighten(desaturate(@sapChart_Sequence_5, 1), 24);
 @sapChart_Sequence_5_Plus3_TextColor: contrast(@sapChart_Sequence_5_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_5_Plus2: lighten(@sapChart_Sequence_5, 16);
+@sapChart_Sequence_5_Plus2: lighten(desaturate(@sapChart_Sequence_5, 5), 15);
 @sapChart_Sequence_5_Plus2_TextColor: contrast(@sapChart_Sequence_5_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_5_Plus1: lighten(@sapChart_Sequence_5, 8);
+@sapChart_Sequence_5_Plus1: lighten(desaturate(@sapChart_Sequence_5, 2), 7);
 @sapChart_Sequence_5_Plus1_TextColor: contrast(@sapChart_Sequence_5_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_5: @sapChart_OrderedColor_5;
 @sapChart_Sequence_5_TextColor: contrast(@sapChart_Sequence_5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3725,7 +3716,7 @@
 @sapChart_Sequence_5_Minus3: darken(saturate(@sapChart_Sequence_5, 10), 18);
 @sapChart_Sequence_5_Minus3_TextColor: contrast(@sapChart_Sequence_5_Minus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_Minus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_Minus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_5_Minus4: darken(saturate(@sapChart_Sequence_5, 10), 26);
+@sapChart_Sequence_5_Minus4: darken(saturate(@sapChart_Sequence_5, 10), 25);
 @sapChart_Sequence_5_Minus4_TextColor: contrast(@sapChart_Sequence_5_Minus4, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_5_Minus4_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_5_Minus4_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_5_Minus5: darken(@sapChart_Sequence_5, 35);
@@ -3734,15 +3725,12 @@
 @sapChart_Sequence_6_Plus3: lighten(desaturate(@sapChart_Sequence_6, 26), 29);
 @sapChart_Sequence_6_Plus3_TextColor: contrast(@sapChart_Sequence_6_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_6_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_6_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_6_Plus2: lighten(desaturate(@sapChart_Sequence_6, 27), 19);
+@sapChart_Sequence_6_Plus2: lighten(desaturate(@sapChart_Sequence_6, 2), 17);
 @sapChart_Sequence_6_Plus2_TextColor: contrast(@sapChart_Sequence_6_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_6_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_6_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_6_Plus1: lighten(desaturate(@sapChart_Sequence_6, 26), 1);
+@sapChart_Sequence_6_Plus1: lighten(desaturate(@sapChart_Sequence_6, 1), 5);
 @sapChart_Sequence_6_Plus1_TextColor: contrast(@sapChart_Sequence_6_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_6_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_6_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_6: @sapChart_OrderedColor_6;
 @sapChart_Sequence_6_TextColor: contrast(@sapChart_Sequence_6, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_6_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_6_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3762,18 +3750,15 @@
 @sapChart_Sequence_6_Minus5: darken(saturate(@sapChart_Sequence_6, 5), 25);
 @sapChart_Sequence_6_Minus5_TextColor: contrast(@sapChart_Sequence_6_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_6_Minus5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_6_Minus5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_7_Plus3: lighten(saturate(@sapChart_Sequence_7, 1), 15);
+@sapChart_Sequence_7_Plus3: lighten(desaturate(@sapChart_Sequence_7, 1), 15);
 @sapChart_Sequence_7_Plus3_TextColor: contrast(@sapChart_Sequence_7_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_7_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_7_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_7_Plus2: lighten(@sapChart_Sequence_7, 10);
+@sapChart_Sequence_7_Plus2: lighten(desaturate(@sapChart_Sequence_7, 2), 17);
 @sapChart_Sequence_7_Plus2_TextColor: contrast(@sapChart_Sequence_7_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_7_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_7_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_7_Plus1: lighten(saturate(@sapChart_Sequence_7, 1), 5);
+@sapChart_Sequence_7_Plus1: lighten(desaturate(@sapChart_Sequence_7, 1), 5);
 @sapChart_Sequence_7_Plus1_TextColor: contrast(@sapChart_Sequence_7_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_7_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_7_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_7: @sapChart_OrderedColor_7;
 @sapChart_Sequence_7_TextColor: contrast(@sapChart_Sequence_7, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_7_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_7_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3793,18 +3778,15 @@
 @sapChart_Sequence_7_Minus5: darken(desaturate(@sapChart_Sequence_7, 18), 36);
 @sapChart_Sequence_7_Minus5_TextColor: contrast(@sapChart_Sequence_7_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_7_Minus5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_7_Minus5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_8_Plus3: lighten(saturate(@sapChart_Sequence_8, 6), 26);
+@sapChart_Sequence_8_Plus3: lighten(desaturate(@sapChart_Sequence_8, 6), 26);
 @sapChart_Sequence_8_Plus3_TextColor: contrast(@sapChart_Sequence_8_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_8_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_8_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_8_Plus2: lighten(saturate(@sapChart_Sequence_8, 2), 17);
+@sapChart_Sequence_8_Plus2: lighten(desaturate(@sapChart_Sequence_8, 2), 17);
 @sapChart_Sequence_8_Plus2_TextColor: contrast(@sapChart_Sequence_8_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_8_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_8_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_8_Plus1: lighten(@sapChart_Sequence_8, 9);
 @sapChart_Sequence_8_Plus1_TextColor: contrast(@sapChart_Sequence_8_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_8_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_8_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_8: @sapChart_OrderedColor_8;
 @sapChart_Sequence_8_TextColor: contrast(@sapChart_Sequence_8, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_8_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_8_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3833,9 +3815,6 @@
 @sapChart_Sequence_9_Plus1: lighten(@sapChart_Sequence_9, 11);
 @sapChart_Sequence_9_Plus1_TextColor: contrast(@sapChart_Sequence_9_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_9_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_9_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_9: @sapChart_OrderedColor_9;
 @sapChart_Sequence_9_TextColor: contrast(@sapChart_Sequence_9, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_9_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_9_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3864,9 +3843,6 @@
 @sapChart_Sequence_10_Plus1: lighten(saturate(@sapChart_Sequence_10, 2), 7);
 @sapChart_Sequence_10_Plus1_TextColor: contrast(@sapChart_Sequence_10_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .35);
 @sapChart_Sequence_10_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_10_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_10: @sapChart_OrderedColor_10;
 @sapChart_Sequence_10_TextColor: contrast(@sapChart_Sequence_10, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .35);
 @sapChart_Sequence_10_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_10_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3895,9 +3871,6 @@
 @sapChart_Sequence_11_Plus1: lighten(desaturate(@sapChart_Sequence_11, 17), 8);
 @sapChart_Sequence_11_Plus1_TextColor: contrast(@sapChart_Sequence_11_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_11_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_11_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_11: @sapChart_OrderedColor_11;
 @sapChart_Sequence_11_TextColor: contrast(@sapChart_Sequence_11, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_11_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_11_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3918,35 +3891,32 @@
 @sapChart_Sequence_11_Minus5_TextColor: contrast(@sapChart_Sequence_11_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_11_Minus5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_11_Minus5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_12_Plus3: lighten(desaturate(@sapChart_Sequence_12, 34), 36);
-@sapChart_Sequence_12_Plus3_TextColor: contrast(@sapChart_Sequence_12_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Plus3_TextColor: contrast(@sapChart_Sequence_12_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Plus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Plus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Plus2: lighten(saturate(@sapChart_Sequence_12, 16), 29);
-@sapChart_Sequence_12_Plus2_TextColor: contrast(@sapChart_Sequence_12_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Plus2: lighten(desaturate(@sapChart_Sequence_12, 16), 29);
+@sapChart_Sequence_12_Plus2_TextColor: contrast(@sapChart_Sequence_12_Plus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Plus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Plus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Plus1: lighten(saturate(@sapChart_Sequence_12, 5), 16);
-@sapChart_Sequence_12_Plus1_TextColor: contrast(@sapChart_Sequence_12_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Plus1: lighten(desaturate(@sapChart_Sequence_12, 5), 16);
+@sapChart_Sequence_12_Plus1_TextColor: contrast(@sapChart_Sequence_12_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_12: @sapChart_OrderedColor_12;
-@sapChart_Sequence_12_TextColor: contrast(@sapChart_Sequence_12, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_TextColor: contrast(@sapChart_Sequence_12, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_12_BorderColor: @sapChart_Sequence_12;
 @sapChart_Sequence_12_Minus1: darken(@sapChart_Sequence_12, 8);
-@sapChart_Sequence_12_Minus1_TextColor: contrast(@sapChart_Sequence_12_Minus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Minus1_TextColor: contrast(@sapChart_Sequence_12_Minus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Minus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Minus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Minus2: darken(saturate(@sapChart_Sequence_12, 17), 20);
-@sapChart_Sequence_12_Minus2_TextColor: contrast(@sapChart_Sequence_12_Minus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Minus2: darken(desaturate(@sapChart_Sequence_12, 17), 20);
+@sapChart_Sequence_12_Minus2_TextColor: contrast(@sapChart_Sequence_12_Minus2, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Minus2_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Minus2_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Minus3: darken(saturate(@sapChart_Sequence_12, 12), 23);
-@sapChart_Sequence_12_Minus3_TextColor: contrast(@sapChart_Sequence_12_Minus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Minus3: darken(desaturate(@sapChart_Sequence_12, 12), 23);
+@sapChart_Sequence_12_Minus3_TextColor: contrast(@sapChart_Sequence_12_Minus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Minus3_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Minus3_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Minus4: darken(saturate(@sapChart_Sequence_12, 12), 27);
-@sapChart_Sequence_12_Minus4_TextColor: contrast(@sapChart_Sequence_12_Minus4, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Minus4: darken(desaturate(@sapChart_Sequence_12, 12), 27);
+@sapChart_Sequence_12_Minus4_TextColor: contrast(@sapChart_Sequence_12_Minus4, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Minus4_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Minus4_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-@sapChart_Sequence_12_Minus5: darken(saturate(@sapChart_Sequence_12, 11), 33);
-@sapChart_Sequence_12_Minus5_TextColor: contrast(@sapChart_Sequence_12_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .5);
+@sapChart_Sequence_12_Minus5: darken(desaturate(@sapChart_Sequence_12, 11), 33);
+@sapChart_Sequence_12_Minus5_TextColor: contrast(@sapChart_Sequence_12_Minus5, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .4);
 @sapChart_Sequence_12_Minus5_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_12_Minus5_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
 @sapChart_Sequence_Bad_Plus3: lighten(@sapChart_Sequence_Bad, 32);
 @sapChart_Sequence_Bad_Plus3_TextColor: contrast(@sapChart_Sequence_Bad_Plus3, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .35);
@@ -3957,9 +3927,6 @@
 @sapChart_Sequence_Bad_Plus1: lighten(@sapChart_Sequence_Bad, 12);
 @sapChart_Sequence_Bad_Plus1_TextColor: contrast(@sapChart_Sequence_Bad_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .35);
 @sapChart_Sequence_Bad_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Bad_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_Bad: @sapChart_Bad;
 @sapChart_Sequence_Bad_TextColor: contrast(@sapChart_Sequence_Bad, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .35);
 @sapChart_Sequence_Bad_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Bad_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -3988,9 +3955,6 @@
 @sapChart_Sequence_Critical_Plus1: lighten(@sapChart_Sequence_Critical, 7);
 @sapChart_Sequence_Critical_Plus1_TextColor: contrast(@sapChart_Sequence_Critical_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_Critical_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Critical_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_Critical: @sapChart_Critical;
 @sapChart_Sequence_Critical_TextColor: contrast(@sapChart_Sequence_Critical, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_Critical_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Critical_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
@@ -4019,9 +3983,6 @@
 @sapChart_Sequence_Good_Plus1: lighten(@sapChart_Sequence_Good, 7);
 @sapChart_Sequence_Good_Plus1_TextColor: contrast(@sapChart_Sequence_Good_Plus1, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_Good_Plus1_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Good_Plus1_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);
-
-// [Tags "!Protected"]
-// [Protected "!true"]
 @sapChart_Sequence_Good: @sapChart_Good;
 @sapChart_Sequence_Good_TextColor: contrast(@sapChart_Sequence_Good, @sapChart_Data_TextColor, @sapChart_Data_ContrastTextColor, .45);
 @sapChart_Sequence_Good_TextShadow: 0 0 .125rem contrast(@sapChart_Sequence_Good_TextColor, @sapContent_ShadowColor, @sapChart_ContrastShadowColor, @sapContent_ContrastTextThreshold);


### PR DESCRIPTION
Problem
In version 1.136 of OpenUI5, headers in the sap_fiori_3 theme appear excessively bold.
This is caused by the @sapFontHeaderFamily variable resolving to a bold font stack:
"72-Bold", "72-Boldfull", "72", "72full", Arial, Helvetica, sans-serif
This made header text rendering appear too heavy compared to previous versions.

Fix
This PR updates the @sapFontHeaderFamily to use @sapFontFamily, restoring the font behavior seen in versions like 1.138, where the issue no longer occurs.

Impact
- Fixes unintended boldness in headers
- Only affects the sap_fiori_3 theme
- Tested locally with correct font rendering

Additional Notes
This change is isolated to themelib_sap_fiori_3 and aligns with visual expectations across themes.

Fixes #4163