### PR TITLE
[FIX] sap.ui.unified.FileUploader: preserve curly braces in displayed tokens

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/FileUploader.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/FileUploader.js
@@ -20,6 +20,7 @@ sap.ui.define([
 	"sap/ui/core/library",
 	"sap/ui/core/StaticArea",
 	"sap/ui/Device",
+	"sap/ui/base/ManagedObject",
 	"./FileUploaderRenderer",
 	"sap/ui/dom/containsOrEquals",
 	"sap/ui/events/KeyCodes",
@@ -45,6 +46,7 @@ sap.ui.define([
 	coreLibrary,
 	StaticArea,
 	Device,
+	ManagedObject,
 	FileUploaderRenderer,
 	containsOrEquals,
 	KeyCodes,
@@ -899,8 +901,8 @@ sap.ui.define([
 		// Add new tokens for selected files
 		this._selectedFileNames.forEach((fileName) => {
 			oTokenizer.addToken(new Token({
-				text: fileName,
-				tooltip: fileName,
+				text: ManagedObject.escapeSettingsValue(fileName),
+				tooltip: ManagedObject.escapeSettingsValue(fileName),
 				selected: false
 			}));
 		});

--- a/src/sap.ui.unified/test/sap/ui/unified/qunit/FileUploader.qunit.js
+++ b/src/sap.ui.unified/test/sap/ui/unified/qunit/FileUploader.qunit.js
@@ -2112,6 +2112,30 @@ sap.ui.define([
 		await nextUIUpdate();
 	});
 
+	QUnit.test("tokens created from selected files containing curly braces", async function (assert) {
+		// arrange
+		var oFileUploader = new FileUploader({ multiple: true });
+		oFileUploader.placeAt("qunit-fixture");
+		await nextUIUpdate();
+
+		// populate tokens with curly braces
+		addFilesToFileUploaderTokenizer(oFileUploader, ["{a}.txt", "prefix_{b}_suffix.txt"]);
+		await nextUIUpdate();
+
+		// assert
+		var oTokenizer = oFileUploader._getTokenizer();
+		var aTokens = oTokenizer.getTokens();
+		assert.strictEqual(aTokens.length, 2, "Tokenizer contains two tokens");
+		assert.strictEqual(aTokens[0].getText(), "{a}.txt", "First token text preserves curly braces");
+		assert.strictEqual(aTokens[0].getTooltip(), "{a}.txt", "First token tooltip preserves curly braces");
+		assert.strictEqual(aTokens[1].getText(), "prefix_{b}_suffix.txt", "Second token text preserves curly braces");
+		assert.strictEqual(aTokens[1].getTooltip(), "prefix_{b}_suffix.txt", "Second token tooltip preserves curly braces");
+
+		// cleanup
+		oFileUploader.destroy();
+		await nextUIUpdate();
+	});
+
 	QUnit.test("tokens cleared when clear() is called", async function (assert) {
 		// arrange
 		var oFileUploader = new FileUploader({ multiple: true });


### PR DESCRIPTION
## Summary

Fixes https://github.com/UI5/openui5/issues/4462

In `sap.ui.unified.FileUploader#_updateTokenizer`, tokens were constructed with raw file names passed to `new Token({ text: fileName, tooltip: fileName })`. When a file name contains curly braces (for example `{test}.txt` or `{foo}bar.txt`), the curly braces are interpreted as UI5 data-binding syntax and stripped in the displayed token text and tooltip.

## Solution

Import `sap/ui/base/ManagedObject` and use `ManagedObject.escapeSettingsValue(fileName)` when creating tokens in `FileUploader.prototype._updateTokenizer`.

## Testing

Added a regression test to `FileUploader.qunit.js` verifying that tokens created from file names containing curly braces (`{a}.txt`, `prefix_{b}_suffix.txt`) preserve the curly braces in both text and tooltip.

cc @dobrinyonkov @boghyon @eliasshhh